### PR TITLE
update code to use newer tensorflow

### DIFF
--- a/part_3/immunotherapy/1_train_model.R
+++ b/part_3/immunotherapy/1_train_model.R
@@ -95,18 +95,19 @@ perf
 
 
 y_pred <- model %>%
-  predict_classes(x_test)
+  predict(x_test) %>% 
+  k_argmax()
 
 y_real <- y_test %>%
   apply(1, function(x) {which(x == 1) - 1 })
 
 peptide_classes <- c("NB", "WB", "SB")
+predicted <- y_pred$numpy()
 results <- tibble(
   measured  = y_real %>% factor(levels = 0:2, labels = peptide_classes),
-  predicted = y_pred %>% factor(levels = 0:2, labels = peptide_classes),
-  Correct = if_else(y_real == y_pred, "yes", "no") %>% factor()
+  predicted = predicted %>% factor(levels = 0:2, labels = peptide_classes),
+  Correct = if_else(y_real == predicted, "yes", "no") %>% factor()
 )
-
 
 results %>%
   ggplot(aes(colour = Correct)) +


### PR DESCRIPTION
Tensorflow deprecated the `predict()` function, so we need to use another mechanism. Unfortunately `renv.lock` still points at the old version of TensorFlow, so we will probably need to update things to make this work with the `renv.lock` file too